### PR TITLE
hyp: short-URL payment redirect for admin link-sharing flow

### DIFF
--- a/apps/store/src/appApi/index.ts
+++ b/apps/store/src/appApi/index.ts
@@ -1806,6 +1806,24 @@ export const useAppApi = () => {
 				});
 				return payment;
 			},
+			async createPaymentRedirect({ order, isJ5 = false }: { order: TOrder; isJ5?: boolean }) {
+				if (!user || !store || !order) return;
+				const res: any = await FirebaseApi.api.createPaymentRedirect({
+					order: { ...order, client: undefined },
+					isJ5,
+					baseUrl: window.location.origin,
+				});
+				logger({
+					message: "admin create payment redirect",
+					severity: "INFO",
+					res,
+					userId: user.uid,
+				});
+				return res;
+			},
+			async getPaymentRedirect({ token }: { token: string }) {
+				return FirebaseApi.api.getPaymentRedirect({ token });
+			},
 			async cancelOrder({ order }: { order: TOrder }) {
 				if (!isValidUser) return;
 				// mixPanelApi.track("ADMIN_ORDER_ACCEPT", {

--- a/apps/store/src/infra/locale/i18n.ts
+++ b/apps/store/src/infra/locale/i18n.ts
@@ -545,6 +545,13 @@ export const resources = {
 			description: "לצערנו, נתקלנו בבעיה טכנית בעיבוד התשלום.\nאל דאגה — ההזמנה שלך נשמרה במערכת ונמצאת בטיפול.\nנציג שלנו ייצור איתך קשר בהקדם להשלמת התשלום.\n\nתודה על הסבלנות ועל האמון!",
 			actionButton: "חזרה לחנות",
 		},
+		payRedirectPage: {
+			loadingTitle: "מעביר לדף התשלום…",
+			loadingDescription: "אנא המתן.",
+			errorTitle: "הקישור אינו תקף",
+			errorDescription: "ייתכן שהקישור פג תוקף או שנעשה בו שימוש. פנה לחנות לקבלת קישור חדש.",
+			actionButton: "חזרה לחנות",
+		},
 		checkout: {
 			title: "פרטי ההזמנה",
 			order: "הזמן",

--- a/apps/store/src/lib/firebase/api.ts
+++ b/apps/store/src/lib/firebase/api.ts
@@ -153,6 +153,42 @@ async function createPayment({ order, isJ5 }: { order: TOrder; isJ5?: boolean })
 		return { success: false, data: null };
 	}
 }
+async function createPaymentRedirect({
+	order,
+	isJ5,
+	baseUrl,
+}: {
+	order: TOrder;
+	isJ5?: boolean;
+	baseUrl: string;
+}) {
+	try {
+		const func = httpsCallable(functions, "createPaymentRedirect");
+		const response = await func({ order, isJ5, baseUrl });
+		return { success: true, data: response.data };
+	} catch (error: any) {
+		const code = error.code;
+		const message = error.message;
+		const details = error.details;
+		console.error(code, message, details);
+		return { success: false, data: null };
+	}
+}
+
+async function getPaymentRedirect({ token }: { token: string }) {
+	try {
+		const func = httpsCallable(functions, "getPaymentRedirect");
+		const response = await func({ token });
+		return { success: true, data: response.data };
+	} catch (error: any) {
+		const code = error.code;
+		const message = error.message;
+		const details = error.details;
+		console.error(code, message, details);
+		return { success: false, data: null };
+	}
+}
+
 async function chargeOrder({ order }: { order: TOrder }) {
 	try {
 		const func = httpsCallable(functions, "chargeOrder");
@@ -300,6 +336,8 @@ export const api = {
 	init,
 	createCompanyClient,
 	createPayment,
+	createPaymentRedirect,
+	getPaymentRedirect,
 	chargeOrder,
 	uiLogs,
 	createInvoice,

--- a/apps/store/src/navigation/index.tsx
+++ b/apps/store/src/navigation/index.tsx
@@ -43,6 +43,9 @@ export const routes = {
 			paymentPending: {
 				path: "/payment-pending",
 			},
+			payRedirect: {
+				path: "/pay/:token",
+			},
 			profile: {
 				path: "/profile",
 			},

--- a/apps/store/src/pages/admin/Orders/AdminOrderPageNew.tsx
+++ b/apps/store/src/pages/admin/Orders/AdminOrderPageNew.tsx
@@ -38,7 +38,6 @@ import { modalApi } from "src/infra/modals";
 import { formatter } from "src/utils/formatter";
 import { useStore } from "src/domains/Store";
 import { useDiscounts } from "src/domains/Discounts/Discounts";
-import { submitHypForm } from "src/lib/payment/submitHypForm";
 
 export default function AdminOrderPageNew() {
 	const { t, i18n } = useTranslation(["common", "ordersPage"]);
@@ -296,14 +295,20 @@ export default function AdminOrderPageNew() {
 										updateOrder(order.id, "cancelled");
 									}
 									if (key === "createPaymentLink") {
-										const payment = await appApi.user.createPaymentLink({
+										const res = await appApi.user.createPaymentRedirect({
 											order,
 											isJ5: false,
 										});
-										if (payment?.data?.formAction && payment?.data?.formFields) {
-											submitHypForm(payment.data.formAction, payment.data.formFields);
-										} else if (payment?.data?.paymentLink) {
-											window.location.href = payment.data.paymentLink;
+										if (res?.data?.success && res.data.url) {
+											// clipboard with alert fallback for browsers that block clipboard in non-secure contexts
+											try {
+												await navigator.clipboard.writeText(res.data.url);
+												alert(`לינק תשלום הועתק:\n${res.data.url}`);
+											} catch {
+												alert(`לינק תשלום:\n${res.data.url}`);
+											}
+										} else {
+											alert("שגיאה ביצירת לינק תשלום");
 										}
 									}
 									if (key === "endOrder") {

--- a/apps/store/src/pages/admin/Orders/AdminOrdersPages.tsx
+++ b/apps/store/src/pages/admin/Orders/AdminOrdersPages.tsx
@@ -6,7 +6,6 @@ import { Price } from "src/components/Price";
 import { Button } from "src/components/button";
 import { TOrder } from "src/domains/Order";
 import { navigate } from "src/navigation";
-import { submitHypForm } from "src/lib/payment/submitHypForm";
 import {
 	ChipProps,
 	Chip,
@@ -177,11 +176,17 @@ function OrderRow({
 					<Button
 						type="button"
 						onPress={async () => {
-							const payment = await appApi.user.createPaymentLink({ order });
-							if (payment?.data?.formAction && payment?.data?.formFields) {
-								submitHypForm(payment.data.formAction, payment.data.formFields);
-							} else if (payment?.data?.paymentLink) {
-								window.location.href = payment.data.paymentLink;
+							const res = await appApi.user.createPaymentRedirect({ order });
+							if (res?.data?.success && res.data.url) {
+								// clipboard with alert fallback for browsers that block clipboard in non-secure contexts
+								try {
+									await navigator.clipboard.writeText(res.data.url);
+									alert(`לינק תשלום הועתק:\n${res.data.url}`);
+								} catch {
+									alert(`לינק תשלום:\n${res.data.url}`);
+								}
+							} else {
+								alert("שגיאה ביצירת לינק תשלום");
 							}
 						}}
 					>

--- a/apps/store/src/pages/store/PayRedirectPage/PayRedirectPage.tsx
+++ b/apps/store/src/pages/store/PayRedirectPage/PayRedirectPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppApi } from "src/appApi";
+import { Button } from "src/components/button";
+import { submitHypForm } from "src/lib/payment/submitHypForm";
+import { navigate, useParams } from "src/navigation";
+
+type Status = "loading" | "error";
+
+export function PayRedirectPage() {
+	const params = useParams("store.payRedirect");
+	const appApi = useAppApi();
+	const { t } = useTranslation(["payRedirectPage"]);
+	const [status, setStatus] = useState<Status>("loading");
+
+	useEffect(() => {
+		if (!params.token) {
+			setStatus("error");
+			return;
+		}
+		appApi.user.getPaymentRedirect({ token: params.token }).then((res: any) => {
+			if (res?.success && res.data?.success && res.data.formAction && res.data.formFields) {
+				submitHypForm(res.data.formAction, res.data.formFields);
+			} else {
+				setStatus("error");
+			}
+		});
+	}, [params.token]);
+
+	if (status === "loading") {
+		return (
+			<div className="min-h-screen w-full flex items-center justify-center p-4 bg-gray-50">
+				<div className="w-full max-w-lg bg-white rounded-2xl shadow-md p-8 text-center" dir="rtl">
+					<div className="mx-auto w-16 h-16 rounded-full bg-blue-100 flex items-center justify-center mb-6">
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							className="w-9 h-9 text-blue-600 animate-spin"
+							aria-hidden="true"
+						>
+							<path d="M21 12a9 9 0 1 1-6.219-8.56" />
+						</svg>
+					</div>
+					<h1 className="text-2xl font-bold text-gray-900 mb-4">
+						{t("payRedirectPage:loadingTitle")}
+					</h1>
+					<p className="text-gray-700 leading-relaxed">
+						{t("payRedirectPage:loadingDescription")}
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="min-h-screen w-full flex items-center justify-center p-4 bg-gray-50">
+			<div className="w-full max-w-lg bg-white rounded-2xl shadow-md p-8 text-center" dir="rtl">
+				<div className="mx-auto w-16 h-16 rounded-full bg-red-100 flex items-center justify-center mb-6">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						className="w-9 h-9 text-red-600"
+						aria-hidden="true"
+					>
+						<circle cx="12" cy="12" r="10" />
+						<line x1="12" y1="8" x2="12" y2="12" />
+						<line x1="12" y1="16" x2="12.01" y2="16" />
+					</svg>
+				</div>
+				<h1 className="text-2xl font-bold text-gray-900 mb-4">
+					{t("payRedirectPage:errorTitle")}
+				</h1>
+				<p className="text-gray-700 leading-relaxed whitespace-pre-line mb-8">
+					{t("payRedirectPage:errorDescription")}
+				</p>
+				<div className="flex justify-center">
+					<div className="w-48">
+						<Button onPress={() => navigate({ to: "store" })} fullWidth>
+							{t("payRedirectPage:actionButton")}
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/store/src/pages/store/StoreLayout.tsx
+++ b/apps/store/src/pages/store/StoreLayout.tsx
@@ -8,6 +8,7 @@ import ProfilePage from "./ProfilePage/ProfilePage";
 import { OrderSuccessPage } from "./OrderSuccessPage/OrderSuccessPage";
 import { OrderErrorPage } from "./OrderErrorPage/OrderErrorPage";
 import { PaymentPendingPage } from "./PaymentPendingPage/PaymentPendingPage";
+import { PayRedirectPage } from "./PayRedirectPage/PayRedirectPage";
 import UserOrdersPage from "./UserOrdersPage";
 import CartPage from "./CartPage/CartPage";
 import { useEffect } from "react";
@@ -115,6 +116,10 @@ export default function StoreLayout() {
 
 					<Route name="store.paymentPending">
 						<PaymentPendingPage />
+					</Route>
+
+					<Route name="store.payRedirect">
+						<PayRedirectPage />
 					</Route>
 
 					<Route name="store.profile">

--- a/functions/src/api/createPaymentRedirect.ts
+++ b/functions/src/api/createPaymentRedirect.ts
@@ -1,0 +1,116 @@
+import { TOrder, TStore } from "@jsdev_ninja/core";
+import * as functions from "firebase-functions/v1";
+import { hypPaymentService } from "../services/hypPaymentService";
+import admin from "firebase-admin";
+import { TStorePrivate } from "src/schema";
+import crypto from "crypto";
+
+// TODO: duplicate of fitAmountToItemsSum in createPayment.ts — factor out when refactoring payment params assembly
+function fitAmountToItemsSum(amount: number, items: string[]): number {
+	const itemsSum = items.reduce((sum, line) => {
+		const m = line.match(/~([\d.]+)~([\d.]+)\]$/);
+		if (!m) return sum;
+		return sum + parseFloat(m[1]) * parseFloat(m[2]);
+	}, 0);
+	const diff = Math.abs(amount - itemsSum);
+	if (diff > 0 && diff <= 0.2) {
+		return itemsSum;
+	}
+	return amount;
+}
+
+// TODO: add admin role gating once role claims are propagated to auth tokens
+export const createPaymentRedirect = functions.https.onCall(
+	async (data: { order: TOrder; isJ5?: boolean; baseUrl: string }, context) => {
+		try {
+			functions.logger.info("createPaymentRedirect", { uid: context.auth?.uid, storeId: context.auth?.token?.storeId });
+
+			const { order, isJ5 = true, baseUrl } = data;
+			const storeId = order.storeId;
+
+			const store: TStore = (
+				await admin.firestore().collection(`STORES`).doc(storeId).get()
+			).data() as TStore;
+
+			const VAT_RATE = 18;
+			const DELIVERY_NAME = "משלוח";
+			const isVatIncluded = order.storeOptions?.isVatIncludedInPrice ?? false;
+			const postVatPrice = (base: number, hasVat: boolean) =>
+				!isVatIncluded && hasVat ? base * (1 + VAT_RATE / 100) : base;
+			const _items = order.cart.items;
+			const items = _items.map((item) => {
+				const price = postVatPrice(item.finalPrice ?? 0, !!item.product.vat).toFixed(2);
+				const sku = (item.product.sku ?? "").trim();
+				const name = (item.product.name[0]?.value ?? "").trim();
+				return `[${sku}~${name}~${item.amount}~${price}]`;
+			});
+			if (order.cart.deliveryPrice) {
+				items.push(`[0~${DELIVERY_NAME}~1~${order.cart.deliveryPrice.toFixed(2)}]`);
+			}
+
+			const storePrivateData: TStorePrivate = (
+				await admin.firestore().collection(`STORES/${storeId}/private`).doc("data").get()
+			).data() as TStorePrivate;
+
+			const nameOnInvoice = order.nameOnInvoice;
+			const adjustedAmount = fitAmountToItemsSum(order.cart.cartTotal, items);
+
+			const res = await hypPaymentService.createPaymentLink({
+				action: "APISign",
+				What: "SIGN",
+				KEY: storePrivateData.hypData.KEY,
+				PassP: storePrivateData.hypData.password,
+				Masof: storePrivateData.hypData.masof,
+				Sign: "True",
+				Amount: adjustedAmount.toString(),
+				J5: isJ5 ? "True" : "False",
+				MoreData: "True",
+				Order: order.id,
+				cell: order.client?.phoneNumber ?? "",
+				ClientName: nameOnInvoice ?? "",
+				ClientLName: "",
+				email: order.client?.email ?? "",
+				street: order.client?.address?.street ?? "",
+				city: order.client?.address?.city ?? "",
+				UserId: "",
+				phone: "",
+				zip: "",
+				Tash: "1",
+				FixTash: "True",
+				Info: order.id,
+				UTF8: "True",
+				UTF8out: "True",
+				sendemail: "True",
+				SendHesh: "True",
+				heshDesc: items.join(""),
+				Pritim: "True",
+			});
+
+			if (!res.success || !res.formAction || !res.formFields) {
+				return { success: false, error: res.errMessage ?? "failed to create payment link" };
+			}
+
+			const token = crypto.randomBytes(32).toString("base64url");
+			const now = Date.now();
+			const expiresAt = now + 48 * 3600 * 1000;
+
+			await admin.firestore().collection("paymentRedirects").doc(token).set({
+				formAction: res.formAction,
+				formFields: res.formFields,
+				expiresAt,
+				createdAt: now,
+				orderId: order.id,
+				storeId,
+				companyId: store.companyId ?? "",
+				usedAt: null,
+			});
+
+			functions.logger.info("createPaymentRedirect success", { token, orderId: order.id, storeId });
+
+			return { success: true, url: `${baseUrl}/pay/${token}`, token, expiresAt };
+		} catch (error: any) {
+			functions.logger.error("createPaymentRedirect error", { message: error.message });
+			return { success: false, error: error.message };
+		}
+	}
+);

--- a/functions/src/api/getPaymentRedirect.ts
+++ b/functions/src/api/getPaymentRedirect.ts
@@ -1,0 +1,37 @@
+import * as functions from "firebase-functions/v1";
+import admin from "firebase-admin";
+
+// Anyone with a valid token can resolve — the token IS the capability. Do not add role gating.
+export const getPaymentRedirect = functions.https.onCall(
+	async (data: { token: string }, _context) => {
+		try {
+			const { token } = data;
+
+			const snap = await admin.firestore().collection("paymentRedirects").doc(token).get();
+
+			if (!snap.exists) {
+				return { success: false, error: "not_found" };
+			}
+
+			const doc = snap.data()!;
+
+			if (Date.now() > doc.expiresAt) {
+				return { success: false, error: "expired" };
+			}
+
+			// fire-and-forget: stamp first use without blocking the response
+			if (doc.usedAt === null) {
+				snap.ref.update({ usedAt: Date.now() }).catch(() => {});
+			}
+
+			return {
+				success: true,
+				formAction: doc.formAction as string,
+				formFields: doc.formFields as Record<string, string>,
+			};
+		} catch (error: any) {
+			functions.logger.error("getPaymentRedirect error", { message: error.message });
+			return { success: false, error: "internal" };
+		}
+	}
+);

--- a/functions/src/index.tsx
+++ b/functions/src/index.tsx
@@ -17,6 +17,8 @@ export { appInit } from "./api/init";
 export { getMixpanelData } from "./api/mixpanel-ts";
 export { createCompanyClient } from "./api/createCompany";
 export { createPayment } from "./api/createPayment";
+export { createPaymentRedirect } from "./api/createPaymentRedirect";
+export { getPaymentRedirect } from "./api/getPaymentRedirect";
 export { chargeOrder } from "./api/chargeOrder";
 export { createInvoice } from "./api/createInvoice";
 export { createDeliveryNote } from "./api/createDeliveryNote";


### PR DESCRIPTION
## Summary

Adds a token-based short-URL flow for the one specific scenario where an **admin sends a payment link to a customer** (via WhatsApp/email/SMS). Customer flow (checkout, re-pay) is intentionally left untouched.

**Stacked on top of [PR #4](https://github.com/jsdev-ninja/stores/pull/4)** — base branch is `claude/naughty-morse-7fa66e`. Once PR #4 merges to main, I'll retarget this PR to `main`.

## Problem

When an admin generates an HYP payment link for a customer and copies it from their browser, the URL contains the full itemized receipt (`heshDesc`). For a 48-item cart this URL is several KB long, and HYP's edge returns **414 Request-URI Too Large** when the customer opens it. Form POST (the fix in PR #4) solves the customer's *own* checkout but doesn't produce a shareable URL.

## Solution — capability URL

Admin clicks "create payment link" → server stores the HYP form fields behind a random token → admin gets a short shareable URL `https://<store-domain>/pay/<token>`. When the customer opens it, a tiny page silently form-POSTs them to HYP's payment page.

### New cloud functions
- **[`createPaymentRedirect`](functions/src/api/createPaymentRedirect.ts)** (callable) — input: `{ order, isJ5?, baseUrl }`. Calls the existing `hypPaymentService.createPaymentLink`, persists `formAction` + `formFields` at `paymentRedirects/<token>` with a 48-hour TTL, returns `{ url, token, expiresAt }`. Token is `crypto.randomBytes(32).toString("base64url")` — 256 bits of entropy, URL-safe.
- **[`getPaymentRedirect`](functions/src/api/getPaymentRedirect.ts)** (callable) — input: `{ token }`. Reads the doc, checks expiry, returns `{ formAction, formFields }` or an error. **No auth gating** — the token IS the capability. Documented inline so a future reviewer doesn't accidentally lock it down.

Firestore doc shape (all timestamps are `number` per project convention, never `Timestamp`):
```ts
paymentRedirects/{token} = {
  formAction, formFields, expiresAt, createdAt,
  orderId, storeId, companyId, usedAt
}
```

### New customer page
- **[`/pay/:token`](apps/store/src/pages/store/PayRedirectPage/PayRedirectPage.tsx)** — on mount, calls `getPaymentRedirect`. On success, calls the existing `submitHypForm` helper to POST the customer to HYP. On error (expired/missing/network), shows a Hebrew error card with a back-to-store button.

### Admin callsite changes
Both admin "create payment link" actions now call `createPaymentRedirect` and copy the short URL to clipboard with a Hebrew confirmation:
- [`AdminOrdersPages.tsx`](apps/store/src/pages/admin/Orders/AdminOrdersPages.tsx) (list row button)
- [`AdminOrderPageNew.tsx`](apps/store/src/pages/admin/Orders/AdminOrderPageNew.tsx) (detail-page action menu)

Clipboard write is wrapped in try/catch — falls back to a plain alert with the URL if the browser blocks clipboard access (e.g. non-secure context, permission denied).

## What this PR does NOT touch
- `CheckoutPage` — customer checkout. Stays on form-POST from PR #4.
- `UserOrdersPage` — customer re-pay. Stays on form-POST from PR #4.
- `chargeOrder`, `createPayment` (existing) — unchanged.
- `submitHypForm` helper — still used by the new page and customer flows.

## Test plan
- [ ] Admin clicks "צור לינק חיוב" on a large order → short URL is copied to clipboard, alert shows the URL.
- [ ] Customer opens the short URL → spinner, then auto-redirected to HYP payment page (no 414).
- [ ] Customer opens an expired/invalid token → Hebrew error card with back-to-store button.
- [ ] Two clicks of "create payment link" produce two different tokens (each has its own random).
- [ ] Customer checkout (CheckoutPage) still works — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)